### PR TITLE
Add role and permission entities with relationships

### DIFF
--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/Permission.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/Permission.java
@@ -1,0 +1,45 @@
+package edu.icesi.pensamiento_computacional.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "PERMISSION", uniqueConstraints = {
+    @UniqueConstraint(name = "uq_permission_name", columnNames = "name")
+})
+public class Permission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, length = 150)
+    private String name;
+
+    @Column(length = 500)
+    private String description;
+
+    @ManyToMany(mappedBy = "permissions", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private Set<Role> roles = new HashSet<>();
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/Role.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/Role.java
@@ -1,0 +1,56 @@
+package edu.icesi.pensamiento_computacional.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "ROLE", uniqueConstraints = {
+    @UniqueConstraint(name = "uq_role_name", columnNames = "name")
+})
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String description;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "ROLE_PERMISSION",
+        joinColumns = @JoinColumn(name = "role_id"),
+        inverseJoinColumns = @JoinColumn(name = "permission_id")
+    )
+    @ToString.Exclude
+    private Set<Permission> permissions = new HashSet<>();
+
+    @ManyToMany(mappedBy = "roles", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private Set<UserAccount> userAccounts = new HashSet<>();
+}

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/UserAccount.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/UserAccount.java
@@ -6,13 +6,13 @@ import java.util.Set;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -50,16 +50,22 @@ public class UserAccount {
     @Column(name="profile_photo_url", nullable=true)
     private String profilePhotoUrl;
 
-    @Column(name="user_type", nullable=false)
-    @Enumerated(EnumType.STRING)
-    private UserType userType;
-
     @Column(name="created_at")
     private LocalDateTime createdAt;
 
-    @ManyToOne(optional=true, fetch=FetchType.LAZY)    
+    @ManyToOne(optional=true, fetch=FetchType.LAZY)
     @JoinColumn(name="self_declared_level")
     private LevelTier selfDeclaredLevel;
+
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "USER_ACCOUNT_ROLE",
+        joinColumns = @JoinColumn(name = "user_account_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    @ToString.Exclude
+    private Set<Role> roles = new HashSet<>();
 
 
     @OneToMany(mappedBy = "createdBy", fetch = FetchType.LAZY)

--- a/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/UserType.java
+++ b/pensamiento-computacional/src/main/java/edu/icesi/pensamiento_computacional/model/UserType.java
@@ -1,5 +1,0 @@
-package edu.icesi.pensamiento_computacional.model;
-
-public enum UserType {
-    STUDENT, PROFESSOR, ADMIN
-}

--- a/pensamiento-computacional/src/main/resources/data.sql
+++ b/pensamiento-computacional/src/main/resources/data.sql
@@ -1,11 +1,47 @@
 -- Tabla: USER_ACCOUNT
-INSERT INTO USER_ACCOUNT (id, institutional_email, password_hash, full_name, profile_photo_url, user_type, created_at, self_declared_level)
+INSERT INTO USER_ACCOUNT (id, institutional_email, password_hash, full_name, profile_photo_url, created_at, self_declared_level)
 VALUES
-(1, 'user1@icesi.edu.co', 'hash1', 'User Uno', NULL, 'STUDENT', CURRENT_TIMESTAMP, NULL),
-(2, 'user2@icesi.edu.co', 'hash2', 'User Dos', NULL, 'PROFESSOR', CURRENT_TIMESTAMP, NULL),
-(3, 'user3@icesi.edu.co', 'hash3', 'User Tres', NULL, 'STUDENT', CURRENT_TIMESTAMP, NULL),
-(4, 'user4@icesi.edu.co', 'hash4', 'User Cuatro', NULL, 'PROFESSOR', CURRENT_TIMESTAMP, NULL),
-(5, 'user5@icesi.edu.co', 'hash5', 'User Cinco', NULL, 'STUDENT', CURRENT_TIMESTAMP, NULL);
+(1, 'user1@icesi.edu.co', 'hash1', 'User Uno', NULL, CURRENT_TIMESTAMP, NULL),
+(2, 'user2@icesi.edu.co', 'hash2', 'User Dos', NULL, CURRENT_TIMESTAMP, NULL),
+(3, 'user3@icesi.edu.co', 'hash3', 'User Tres', NULL, CURRENT_TIMESTAMP, NULL),
+(4, 'user4@icesi.edu.co', 'hash4', 'User Cuatro', NULL, CURRENT_TIMESTAMP, NULL),
+(5, 'user5@icesi.edu.co', 'hash5', 'User Cinco', NULL, CURRENT_TIMESTAMP, NULL);
+
+-- Tabla: PERMISSION
+INSERT INTO PERMISSION (id, name, description)
+VALUES
+(1, 'VIEW_ACTIVITIES', 'Permite consultar las actividades disponibles'),
+(2, 'SUBMIT_SOLUTIONS', 'Permite enviar respuestas para ejercicios'),
+(3, 'GRADE_SUBMISSIONS', 'Permite evaluar y asignar puntajes a respuestas'),
+(4, 'MANAGE_USERS', 'Permite administrar usuarios y roles de la plataforma');
+
+-- Tabla: ROLE
+INSERT INTO ROLE (id, name, description)
+VALUES
+(1, 'STUDENT', 'Rol para estudiantes inscritos en los cursos'),
+(2, 'PROFESSOR', 'Rol para profesores encargados de evaluar actividades'),
+(3, 'ADMIN', 'Rol administrativo con privilegios de gestión');
+
+-- Tabla intermedia: ROLE_PERMISSION
+INSERT INTO ROLE_PERMISSION (role_id, permission_id)
+VALUES
+(1, 1),
+(1, 2),
+(2, 1),
+(2, 3),
+(3, 1),
+(3, 3),
+(3, 4);
+
+-- Tabla intermedia: USER_ACCOUNT_ROLE
+INSERT INTO USER_ACCOUNT_ROLE (user_account_id, role_id)
+VALUES
+(1, 1),
+(2, 2),
+(2, 3),
+(3, 1),
+(4, 2),
+(5, 1);
 
 -- Tabla: LEVEL_TIER
 INSERT INTO LEVEL_TIER (code)


### PR DESCRIPTION
## Summary
- introduce Permission and Role entities including many-to-many mapping for permissions assigned to roles
- link UserAccount records to roles through a join table and seed demo associations in data.sql
- remove the legacy UserType enum in favor of role-based authorization data

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb42ab18e8832ea26be25f7ea88916