### PR TITLE
Configure Jacoco coverage checks

### DIFF
--- a/pensamiento-computacional/pom.xml
+++ b/pensamiento-computacional/pom.xml
@@ -29,6 +29,8 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<jacoco.version>0.8.11</jacoco.version>
+		<jacoco.service.coverage.minimum>0.50</jacoco.service.coverage.minimum>
 	</properties>
 
 	<dependencies>
@@ -88,6 +90,50 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>CLASS</element>
+									<includes>
+										<include>edu/icesi/pensamiento_computacional/services/**/*.class</include>
+									</includes>
+									<limits>
+										<limit>
+											<counter>LINE</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>${jacoco.service.coverage.minimum}</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- add JaCoCo configuration to the Maven build so coverage is collected during the test/verify lifecycle
- enforce minimum line coverage for service classes through a configurable rule

## Testing
- mvn -q verify *(fails: unable to resolve Spring Boot parent POM in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4a79b858832eaba4818f596f46b5