### PR TITLE
Configure SQL initialization scripts for schema-first startup

### DIFF
--- a/pensamiento-computacional/src/main/resources/application.properties
+++ b/pensamiento-computacional/src/main/resources/application.properties
@@ -14,6 +14,8 @@ spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
 spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:/schema.sql
+spring.sql.init.data-locations=classpath:/data.sql
 spring.jpa.defer-datasource-initialization=true
 spring.h2.console.settings.web-Allow-Others=true
 

--- a/pensamiento-computacional/src/test/resources/application-test.properties
+++ b/pensamiento-computacional/src/test/resources/application-test.properties
@@ -16,6 +16,8 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:/schema.sql
+spring.sql.init.data-locations=classpath:/data.sql
 spring.jpa.defer-datasource-initialization=true
 spring.h2.console.enabled=false
 


### PR DESCRIPTION
## Summary
- point spring.sql.init schema and data locations to classpath scripts in the main application profile so the schema runs before seed data
- mirror the same SQL initialization locations in the test profile for consistency

## Testing
- `mvn clean test` *(fails: Non-resolvable parent POM due to network being unreachable when downloading org.springframework.boot:spring-boot-starter-parent:3.5.5)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6268756c832eb80fa8e1897282db